### PR TITLE
docs: link to project setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,10 @@ We welcome code contributions to the 2FAS for Android project. If you are intere
 1. Fork this repository to your own GitHub account
 2. Clone the repository to your local machine
 3. Create a new branch for your changes (e.g. `feature/new-login-screen`)
-4. Make your changes and commit them to your branch
-5. Push your branch to your fork on GitHub
-6. Open a pull request from your branch to the `develop` branch of this repository
+4. Follow the [Project Setup](#project-setup)
+5. Make your changes and commit them to your branch
+6. Push your branch to your fork on GitHub
+7. Open a pull request from your branch to the `develop` branch of this repository
 
 Please make sure your pull request includes the following:
 

--- a/README.md
+++ b/README.md
@@ -28,17 +28,7 @@ We use GitHub for bug reports. Please visit the [2FAS for Android issues page](h
 
 ## Contributing
 
-We welcome contributions to the Open Source 2FAS project. If you would like to contribute, please follow these steps:
-
-1. Fork the repository.
-2. Create a new branch for your changes.
-3. Make your changes.
-4. Commit your changes and push them to your fork.
-5. Create a new pull request from your fork to the `master` branch of the main repository.
-
-We will review your pull request and, if it is approved, merge it into the main codebase.
-
-By sharing ideas and code with the 2FAS community, either through GitHub or Discord, you agree that these contributions become the property of the 2FAS community and may be implemented into the 2FAS open source code.
+We welcome contributions to the Open Source 2FAS project. If you would like to contribute, please see the [contribution guide](./CONTRIBUTING.md).
 
 ## Donations
 


### PR DESCRIPTION
Fixes the problem I had in #18 where I missed the contributing file because the README already had a contributing section.

This pr replaces the old contributing section in the README with a link to the contributing file, which already contains the section.
It also links to the project setup, so it is more visible.