### PR TITLE
Remove setting of Android NavigationBarColor to background color

### DIFF
--- a/core/designsystem/src/main/java/com/twofasapp/designsystem/AppTheme.kt
+++ b/core/designsystem/src/main/java/com/twofasapp/designsystem/AppTheme.kt
@@ -88,7 +88,7 @@ fun MainAppTheme(
     }
 
     SideEffect {
-        systemUiController.setSystemBarsColor(color = colors.background)
+        systemUiController.setStatusBarColor(color = colors.background)
     }
 
     CompositionLocalProvider(

--- a/core/designsystem/src/main/java/com/twofasapp/designsystem/AppTheme.kt
+++ b/core/designsystem/src/main/java/com/twofasapp/designsystem/AppTheme.kt
@@ -1,7 +1,7 @@
 package com.twofasapp.designsystem
 
 import android.app.Activity
-import android.view.WindowManager
+import android.view.View
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
@@ -10,11 +10,13 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.twofasapp.designsystem.internal.LocalThemeColors
 import com.twofasapp.designsystem.internal.ThemeColors
@@ -25,6 +27,16 @@ val LocalAppTheme = staticCompositionLocalOf { AppTheme.Auto }
 
 enum class AppTheme {
     Auto, Light, Dark,
+}
+
+@Composable
+fun isGestureNavigationEnabled(view: View): Boolean {
+    val windowInsets = WindowInsetsCompat.toWindowInsetsCompat(
+        view.rootWindowInsets, view
+    )
+    val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemGestures())
+
+    return insets.left > 0 && insets.right > 0
 }
 
 @Composable
@@ -89,6 +101,12 @@ fun MainAppTheme(
 
     SideEffect {
         systemUiController.setStatusBarColor(color = colors.background)
+    }
+
+    if (!isGestureNavigationEnabled(view)) {
+        SideEffect {
+            systemUiController.setNavigationBarColor(color = colors.background)
+        }
     }
 
     CompositionLocalProvider(


### PR DESCRIPTION
### **Issue:**
The Android Navigation Bar has a different color to the Navigation bar of the app

![issue-light](https://github.com/twofas/2fas-android/assets/3381481/62747ebe-2971-4039-9bbd-2c816d9f948d)
![issue-dark](https://github.com/twofas/2fas-android/assets/3381481/b58c3978-1016-4864-afcb-dd80ac0fcd22)

### **Changes made:**
`setSystemBarsColor()` calls both `setStatusBarColor()` and `setNavigationBarColor()`

However, we only want to set the Status Bar to the color of the background (not the Android Navigation Bar).

This isn't a written guideline in Material 3, but the vast majority of the designs shown have an Android Navigation Bar color matching the Navigation Bar of the app 
See: https://m3.material.io/components/navigation-bar/overview

### **After changes:**
The Android Navigation Bar now matches the Navigation Bar of the app without affecting the screens without an app Navigation Bar

![fixed-light](https://github.com/twofas/2fas-android/assets/3381481/c6e47ebd-27e2-4e56-8b90-1ade51883c1f)
![fixed-dark](https://github.com/twofas/2fas-android/assets/3381481/2237ff91-dd2b-4dcf-acc8-c062c6998db9)

### **Dependency changes:**
None

### **Tests affected:**
None