### PR TITLE
Fix NullPointerException when paramters key in URI contains semicolon

### DIFF
--- a/data/services/src/main/java/com/twofasapp/data/services/otp/OtpLinkParser.kt
+++ b/data/services/src/main/java/com/twofasapp/data/services/otp/OtpLinkParser.kt
@@ -55,7 +55,9 @@ object OtpLinkParser {
     private fun isAuthorityValid(uri: Uri) =
         uri.authority?.lowercase() == TOTP || uri.authority?.lowercase() == HOTP || uri.authority?.lowercase() == STEAM
 
-    private fun mapQueryParams(uri: Uri) = uri.queryParameterNames.associateWith { uri.getQueryParameter(it)!! }
+    private fun mapQueryParams(uri: Uri) = uri.queryParameterNames.associateWith {
+        uri.getQueryParameter(it) ?: "" // getQueryParameter() is nullable when parameters key contains semicolon
+    }
 
     private fun getPath(uri: Uri): String {
         if (uri.path == null) return ""


### PR DESCRIPTION
### Issue
When a semicolon is used in parameter key of the URI provided by the QR code, a `NullPointerException` occurs in the `mapQueryParams` function, resulting in the message `This QR Code does not work!` being displayed and the QR code unable to be loaded. This fix addresses the issue.

### Effects of this fix

With this fix, services that generate URIs contains semicolon (`;`), such as SimpleLogin with `...&amp;issuer=...` in the URI, will also be registerable. (Such URI can be loaded in other apps like Microsoft Authenticator and Authy as well.)

You can verify the fix using the following QR code generator:

[https://stefansundin.github.io/2fa-qr/](https://stefansundin.github.io/2fa-qr/)

Test URIs:

- `otpauth://totp/SAMPLE?secret=SAMPLE123&amp;issuer=Example`
    - Contains a semicolon in the parameter name; similar to output from SimpleLogin (maybe their's bug)

### Previous behavior before the fix
Displays "This QR Code does not work!" and cannot be registered.

### Behavior after the fix
Registration is possible without displaying an error, similar to other apps.


Thank you.