### PR TITLE
Use password keyboard type for inputs in PasswordDialog

### DIFF
--- a/core/designsystem/src/main/java/com/twofasapp/designsystem/dialog/PasswordDialog.kt
+++ b/core/designsystem/src/main/java/com/twofasapp/designsystem/dialog/PasswordDialog.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
@@ -36,7 +37,9 @@ fun PasswordDialog(
     onPositive: ((String) -> Unit)? = null,
     onNegative: (() -> Unit)? = null,
     validation: ((String) -> Boolean)? = null,
-    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default.copy(
+        keyboardType = KeyboardType.Password,
+    ),
     minLength: Int = 3,
     maxLength: Int = Int.MAX_VALUE,
     confirmRequired: Boolean = true,


### PR DESCRIPTION
This disables dictionary and autocorrect for password inputs, which could leak entered passwords. Fixes #152