### PR TITLE
Do not lock screen rotation on tablets

### DIFF
--- a/core/designsystem/src/main/java/com/twofasapp/designsystem/AppTheme.kt
+++ b/core/designsystem/src/main/java/com/twofasapp/designsystem/AppTheme.kt
@@ -34,8 +34,10 @@ enum class AppTheme {
 fun MainAppTheme(
     content: @Composable () -> Unit
 ) {
-    LockScreenOrientation(orientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
-
+    if (!isTablet()) {
+        LockScreenOrientation(orientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
+    }
+    
     val view = LocalView.current
     val systemUiController = rememberSystemUiController()
 
@@ -97,6 +99,12 @@ fun MainAppTheme(
             content = content,
         )
     }
+}
+
+@Composable
+fun isTablet(): Boolean {
+    val configuration = LocalContext.currentActivity.resources.configuration
+    return (configuration.screenLayout and Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_LARGE
 }
 
 @Composable


### PR DESCRIPTION
I would appreciate that the screen rotation is not locked on tablets
I am not an android developer, but this works on my Samsung Tablet and still locks the screen rotation in the Android Emulator using a Medium Phone.