### PR TITLE
Skip unneeded confirmation button when using passive biometrics such as face unlock

### DIFF
--- a/feature/security/src/main/java/com/twofasapp/feature/security/ui/biometric/BiometricDialog.kt
+++ b/feature/security/src/main/java/com/twofasapp/feature/security/ui/biometric/BiometricDialog.kt
@@ -40,6 +40,7 @@ fun BiometricDialog(
         .setTitle(title)
         .setSubtitle(subtitle)
         .setNegativeButtonText(negative)
+        .setConfirmationRequired(false)
         .build()
 
     val callback = object : BiometricPrompt.AuthenticationCallback() {


### PR DESCRIPTION
Fixes #162.

As explained in the [Android docs](https://developer.android.com/identity/sign-in/biometric-auth#no-explicit-user-action), low-risk actions (such as logging into an app) should not require an explicit action by the user when using a passive biometric authentication method, such as the secure face unlock used by newer Pixel phones. This is only meant for high-risk operations such as purchases.

Unfortunately, the Biometrics API defaults to `true` for this, which makes the experience unnecessarily cumbersome. To fix it, we just need to pass the `.setConfirmationRequired(false)` flag to the biometric prompt builder, which will make the authentication experience much smoother, just like it is on iPhones.

Submitting this super simple PR in hopes of getting this moving, as I see the issue has remained unaddressed for some time now ;-) 