### PR TITLE
Add Simplified Chinese (zh-CN) localization

### DIFF
--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -13,6 +13,7 @@
     <locale android:name="nl" />
     <locale android:name="tr" />
     <locale android:name="zh" />
+    <locale android:name="zh-rCN" />
     <locale android:name="el" />
     <locale android:name="ja" />
     <locale android:name="sv" />

--- a/core/locale/src/debug/res/values-zh-rCN/strings.xml
+++ b/core/locale/src/debug/res/values-zh-rCN/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="android__app_name">2FAS.DEBUG</string>
+</resources> 

--- a/core/locale/src/main/res/values-zh-rCN/strings.xml
+++ b/core/locale/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,911 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Loco xml export: Android string resources
+ Project: 2FAS App
+ Locale: zh-Hant, Traditional Chinese
+ Exported by: rafakob
+ Exported at: Sun, 20 Jul 2025 03:30:40 -0700
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- InfoPlist.strings
+        TwoFAS
+        Created by Zbigniew Cisiński on 14/03/2020.
+        Copyright © 2020 The Code. All rights reserved. -->
+    <string name="NSCameraUsageDescription">用於掃描 QR 碼</string>
+    <string name="NSFaceIDUsageDescription">您可以使用 Face ID 解鎖應用程式</string>
+    <!-- MARK: - App -->
+    <string name="app__name">2FAS 身份驗證器</string>
+    <string name="commons__2fas">2FA 身份驗證器（2FAS 應用程式）</string>
+    <string name="commons__OK">好的</string>
+    <string name="commons__add">新增</string>
+    <!-- MARK: - Commons -->
+    <string name="commons__cancel">取消</string>
+    <string name="commons__notifications">通知</string>
+    <!-- A number replaces %d, for example, 4 of 5. -->
+    <string name="commons__page_of_page_title">第 %1$d 個 ，共 %2$d 個</string>
+    <!-- notifications__service_already_removed_from_backup -->
+    <string name="notifications__service_already_removed_title">已從備份中刪除的服務</string>
+    <!-- notifications__service_already_modified_in_backup -->
+    <string name="notifications__service_already_modified_title">備份中已修改的服務</string>
+    <!-- backup__user_is_over_quota_on_icloud -->
+    <string name="backup__user_over_quota_icloud">使用者在 iCloud 上的配額已滿</string>
+    <!-- backup__icloud_is_not_available -->
+    <string name="backup__icloud_not_available">iCloud 無法使用</string>
+    <!-- backup__icloud_has_been_disabled_by_user -->
+    <string name="backup__icloud_disabled_title">使用者已停用 iCloud</string>
+    <!-- backup__turned_off_description_bold_part -->
+    <string name="backup__2fas_backup">2FAS 備份</string>
+    <string name="commons__close">關閉</string>
+    <string name="commons__continue">繼續</string>
+    <string name="commons__copy">複製</string>
+    <string name="commons__delete">刪除</string>
+    <string name="commons__dismiss">取消</string>
+    <string name="commons__done">已完成</string>
+    <string name="commons__edit">編輯</string>
+    <string name="commons__enter_code_manually">手動輸入驗證碼</string>
+    <string name="commons__error">錯誤</string>
+    <string name="commons__info">資訊</string>
+    <string name="commons__next">下一步</string>
+    <string name="commons__notice">通知</string>
+    <string name="commons__off">關閉</string>
+    <string name="commons__on">啟用</string>
+    <!-- commons__point_your_camera_at_code_on_website -->
+    <string name="commons__camera_title">將相機對準螢幕捕捉 QR 碼</string>
+    <string name="commons__rename">重新命名</string>
+    <string name="commons__retry">再試一次</string>
+    <string name="commons__save">儲存</string>
+    <string name="commons__scan_qr_code">掃描 QR 碼</string>
+    <string name="commons__service">服務</string>
+    <string name="commons__set">設定</string>
+    <string name="commons__skip">跳過</string>
+    <string name="commons__tokens">權杖</string>
+    <string name="commons__warning">警告</string>
+    <string name="commons__no_results">沒有結果</string>
+    <string name="commons__customize">自訂</string>
+    <string name="commons__approve">批准</string>
+    <string name="commons__deny">拒絕</string>
+    <!-- max. %d chars = Maximum number of characters
+        commons__provided_text_too_long -->
+    <string name="commons__text_long_title">提供的文字過長（最多 %d 字元）</string>
+    <string name="commons__got_it">知道了！</string>
+    <string name="fingerprint__verifying">驗證…</string>
+    <!-- fingerprint__setup_content -->
+    <string name="fingerprint__confirm_title">確認指紋以繼續。</string>
+    <!-- fingerprint__use_pin -->
+    <string name="fingerprint__use_pin_title">這次使用 PIN 碼</string>
+    <!-- MARK: - Introduction -->
+    <string name="introduction__page_1_title">你真棒！</string>
+    <string name="introduction__page_1_content">有了 2FAS 應用程式，您的手機就成了您線上服務的私人安全金鑰。 2FAS 應用程式 — 深受全球 600 多萬使用者的信賴。</string>
+    <string name="introduction__page_2_title">簡單</string>
+    <string name="introduction__page_2_content">將 2FAS 與您的線上服務配對，使用 QR 碼在幾秒鐘內啟動雙重認證。</string>
+    <string name="introduction__page_3_title">隱私</string>
+    <string name="introduction__page_3_content">2FAS 尊重並保護您的隱私。本應用程式絕不會收集、處理或使用您的任何個人資料。</string>
+    <string name="introduction__page_4_title">安全</string>
+    <string name="introduction__page_4_content_ios">由於您的令牌透過設備離線儲存，所以記得備份你的服務！使用 iCloud 同步和 PIN 碼來防止未經授權的存取和裝置損壞。</string>
+    <!-- introduction__start_using -->
+    <string name="introduction__title">開始使用 2FAS</string>
+    <string name="introduction__tos">服務條款</string>
+    <string name="introduction__description_title">將您的線上服務帳戶與 2FAS 配對或匯入您的權杖</string>
+    <string name="introduction__pair_new_service">配對新服務</string>
+    <!-- introduction__import_2fas -->
+    <string name="introduction__import_2fas_title">匯入 2FAS 備份檔案</string>
+    <!-- introduction__import_ga -->
+    <string name="introduction__import_google_authenticator">從 Google Authenticator 匯入</string>
+    <!-- introduction__not_sure -->
+    <string name="introduction__what_to_do">不知道該怎麼做？</string>
+    <!-- introduction__ga_import_description -->
+    <string name="introduction__google_authenticator_import_process">使用「轉移帳號」選項將您的帳戶從 Google Authenticator 匯出為 QR 碼。然後使用另一台裝置拍攝匯出的二維碼圖片，傳送到您的裝置（儘可能截圖），並使用下面的「選擇二維碼」選項。如果您正在從另一台裝置匯入代碼，請使用「掃描 QR 碼」按鈕。</string>
+    <!-- introduction__choose_qr -->
+    <string name="introduction__choose_qr_code">選擇 QR 碼</string>
+    <!-- introduction__scan_qr -->
+    <string name="introduction__scan_qr_code">掃描 QR 碼</string>
+    <!-- Original: Adding code -->
+    <string name="notifications__adding_code">新增新代碼</string>
+    <!-- notifications__private_key_copied -->
+    <string name="notifications__service_key_copied">金鑰已複製</string>
+    <!-- voiceover__token_is_already_on_the_list -->
+    <string name="notifications__token_already_added">此權杖已經在清單裡。</string>
+    <string name="notifications__counter_copied">計數器已複製</string>
+    <string name="notifications__token_copied">權杖已複製</string>
+    <string name="notifications__next_token_copied">下一個權杖已複製</string>
+    <!-- notifications__would_you_like_to_add_this_code -->
+    <string name="notifications__add_code_question_title">您想新增以下代碼嗎： %s？</string>
+    <!-- MARK: - Permissions -->
+    <string name="permissions__open_settings">開啟設定</string>
+    <string name="security__incorrect_PIN">PIN 碼錯誤</string>
+    <string name="security__change_pin">變更 PIN 碼</string>
+    <string name="security__confirm_you_are_device_owner">請確認您是裝置擁有者</string>
+    <!-- security__confirm_your_new_pin -->
+    <string name="security__confirm_new_pin">請確認您的新 PIN 碼</string>
+    <string name="security__create_pin">建立 PIN 碼</string>
+    <string name="security__enter_current_pin">請輸入您目前的 PIN 碼</string>
+    <!-- security__enter_your_new_pin -->
+    <string name="security__enter_new_pin">請輸入您的新 PIN 碼</string>
+    <!-- security__enter_your_pin -->
+    <string name="security__enter_pin">請輸入您的 PIN 碼</string>
+    <!-- MARK: - Security -->
+    <string name="security__too_many_attempts_try_again_after_formatter">嘗試次數過多，請再試一次 %s</string>
+    <string name="security__too_many_attempts_try_again_after">嘗試次數過多，請在%s分鐘後再試一次。</string>
+    <!-- security__too_many_attempts_try_again_later -->
+    <string name="security__too_many_attempts_error">嘗試次數過多，請稍後再試一次。</string>
+    <!-- security__too_many_attempts_try_again_after_one_minute -->
+    <string name="security__too_many_attempts_error_2">嘗試次數過多，請在一分鐘後再試一次。</string>
+    <string name="settings__backup_and_synchronization">備份與同步</string>
+    <string name="settings__choose_topic">選擇主題</string>
+    <string name="settings__configure_mail_service_try_again">設定郵件服務並再試一次</string>
+    <string name="settings__general">一般</string>
+    <string name="settings__mail_services_not_available">未提供郵件服務</string>
+    <string name="settings__problem">問題</string>
+    <string name="settings__security">安全性</string>
+    <string name="settings__select_pin_length">選擇 PIN 碼長度</string>
+    <string name="settings__settings">設定</string>
+    <!-- czy to dalej będzie w aplikacji? -->
+    <string name="settings__suggestion">建議</string>
+    <string name="settings__advanced">進階</string>
+    <string name="settings__widgets">小工具</string>
+    <string name="settings__display_selected_services">在主螢幕小工具上顯示已選定的服務。</string>
+    <!-- settings__after_you_enable_widgets -->
+    <string name="settings__widgets_title">啟用小工具後，無需 PIN 碼即可存取您的所有權杖。\n\n您確定要啟用小工具嗎？</string>
+    <string name="settings__show_next_token">顯示下一個權杖</string>
+    <string name="settings__see_incoming_tokens">在清單上檢視接收到的權杖</string>
+    <string name="settings__trash">資源回收筒</string>
+    <string name="settings__restore">還原</string>
+    <string name="settings__trash_is_empty">資源回收筒已清空</string>
+    <string name="settings__share_app">分享應用程式</string>
+    <!-- tokens__remove_from_list -->
+    <string name="tokens__delete_token">您確定要刪除以下權杖嗎：</string>
+    <string name="tokens__move_to_trash">移至資源回收筒</string>
+    <string name="tokens__additional_info">其他資訊</string>
+    <string name="tokens__choose_method">選擇方法</string>
+    <string name="tokens__duplicated_private_key">金鑰已重複</string>
+    <!-- tokens__incorrect_private_key -->
+    <string name="tokens__incorrect_service_key">金鑰錯誤：僅限允許使用數字 2 到 7 和字母，最大長度為 512 個字元。</string>
+    <string name="tokens__try_again">好的，讓我們再試一次</string>
+    <!-- Original: To capture the QR code
+        tokens__point_right_2fa_code -->
+    <string name="tokens__scan_qr_code_title">將相機對準螢幕掃描 QR 碼</string>
+    <!-- tokens__private_key -->
+    <string name="tokens__service_key">金鑰</string>
+    <string name="tokens__qr_code_leads_to_app_store">此 QR 碼將帶您前往 App Store</string>
+    <!-- tokens__remove_it_forever -->
+    <string name="tokens__remove_forever">刪除權杖</string>
+    <!-- tokens__search_by_service_name_or_login -->
+    <string name="tokens__search_service_title">搜尋服務</string>
+    <!-- tokens__search_sorry_service_not_found -->
+    <string name="tokens__service_not_found_search">對不起，未找到服務</string>
+    <!-- Original: Take another try with a different search term
+        tokens__search_take_another_try_different_search_term -->
+    <string name="tokens__try_different_search_term">換個搜尋字詞再試一次</string>
+    <string name="tokens__service_key_to_short">密鑰太短，需要至少 4 個字元</string>
+    <string name="tokens__service_name">服務名稱</string>
+    <!-- tokens__this_private_key_exists_used_in -->
+    <string name="tokens__service_key_already_used_title">掃描 QR 碼中的金鑰已在 %s 中使用，您可能重複掃描。</string>
+    <string name="tokens__this_qr_code_is_inavlid">此代碼不正確或不受支援，請再試一次。</string>
+    <string name="tokens__type_service_name">輸入服務名稱</string>
+    <string name="tokens__enter_service_name">輸入服務名稱</string>
+    <!-- tokens__unfortunately_we_dont_know_that_service_name_it -->
+    <string name="tokens__service_name_unknown_title">很遺憾，我們不知道這項服務。您想如何命名？</string>
+    <!-- tokens__you_wont_be_able_to_restore -->
+    <string name="tokens__token_not_possible_to_restore">您將無法再還原此權杖。</string>
+    <string name="tokens__badge_color">徽章顏色</string>
+    <string name="tokens__change_brand_icon">變更品牌圖示</string>
+    <string name="tokens__change_label">變更標籤</string>
+    <string name="tokens__service_information">服務資訊</string>
+    <string name="tokens__personalization">個性化</string>
+    <string name="tokens__brand_icon">品牌圖示</string>
+    <string name="tokens__label">標籤</string>
+    <!-- tokens__remove_the_service -->
+    <string name="tokens__remove_service_from_app">從 2FAS 應用程式中移除此服務</string>
+    <!-- tokens__label_one_or_two -->
+    <string name="tokens__label_characters_title">標籤（1 或 2 個字元）：</string>
+    <string name="tokens__pick_background_color">選取背景顏色：</string>
+    <string name="tokens__num_added">%s 已新增</string>
+    <string name="tokens__next_token">下一個權杖： %s</string>
+    <string name="tokens__next_token_title">下一個權杖的值</string>
+    <string name="tokens__my_tokens">我的權杖</string>
+    <string name="tokens__removing_group">刪除群組</string>
+    <!-- tokens__all_tokens_will_be_moved -->
+    <string name="tokens__all_tokens_moved_to_group_title">所有權杖將會移動至群組中： 「我的權杖」。</string>
+    <string name="tokens__add_group">新增群組</string>
+    <string name="tokens__group_name">群組名稱：</string>
+    <string name="tokens__select_from_gallery">從相簿中選擇</string>
+    <string name="tokens__camera_is_unavailable">相機不可用</string>
+    <!-- tokens__check_if_app_has_proper_permissions -->
+    <string name="tokens__check_app_permissions">請檢查本應用程式在系統設定中是否具有權限</string>
+    <string name="tokens__no_qr_codes_found">未找到 QR 碼</string>
+    <!-- tokens__no_correct_qr_code_had_been_found
+        
+        No correct QR codes had been found in the selected image. Please try a different image. -->
+    <string name="tokens__no_correct_qr_code_found_title">所選圖片中沒有正確的 QR 碼，請嘗試其他圖片。</string>
+    <string name="tokens__select_service">選擇服務</string>
+    <string name="tokens__adding_service_question_title">您想新增什麼服務？</string>
+    <string name="tokens__retype_this_token">重新輸入此權杖</string>
+    <!-- tokens__unlock_and_retype_this_token -->
+    <string name="tokens__unlock_and_retype_token_title">解鎖並重新輸入此權杖</string>
+    <string name="tokens__group">群組</string>
+    <string name="tokens__select_group">選擇群組</string>
+    <string name="tokens__google_auth_import">從 Google Authenticator 應用程式匯入 2FA 權杖</string>
+    <string name="tokens__google_auth_import_subtitle">此 QR 碼可從 Google Authenticator 匯入令牌</string>
+    <!-- A number replaces %d  -->
+    <string name="tokens__google_auth_out_of_title">%1$d 中的 %2$d</string>
+    <string name="tokens__google_auth_import_subtitle_end">權杖將被匯入。</string>
+    <string name="tokens__sort_by">排序方式</string>
+    <!-- tokens__sort_by_az -->
+    <string name="tokens__sort_by_a_to_z">A - Z</string>
+    <!-- tokens__sort_by_za -->
+    <string name="tokens__sort_by_z_to_a">Z - A</string>
+    <string name="tokens__sort_by_manual">手動</string>
+    <string name="tokens__advanced">進階</string>
+    <!-- tokens__advanced_alert_title -->
+    <string name="tokens__advanced_alert">提醒</string>
+    <!-- tokens__advanced_alert_description -->
+    <string name="tokens__advanced_alert_description_title">不建議變更進階設定。只有在您的 2FA 提供者要求且您有明確指示的情況下，才可以進行變更。</string>
+    <string name="tokens__token_settings">權杖設定</string>
+    <string name="tokens__otp_authentication">OTP 身份驗證</string>
+    <string name="tokens__algorithm">演算法</string>
+    <string name="tokens__refresh_time">重新整理時間</string>
+    <string name="tokens__number_of_digits">位數</string>
+    <string name="tokens__counter">計數器</string>
+    <string name="tokens__initial_counter">初始計數器</string>
+    <!-- A number replaces %d -->
+    <string name="tokens__second">%d 秒</string>
+    <string name="tokens__hotp">HOTP</string>
+    <string name="tokens__totp">TOTP</string>
+    <string name="tokens__advanced_settings_footer_title">不建議變更進階設定。只有在您的 2FA 提供者要求且您有明確指示的情況下，才可以進行變更。</string>
+    <string name="tokens__gallery_advice_title">最佳範例</string>
+    <!-- ADD A SPACE AT THE END -->
+    <string name="tokens__gallery_advice_content_first">服務已成功新增。我們強烈建議您…</string>
+    <!-- ADD A SPACE AFTER COMA -->
+    <string name="tokens__gallery_advice_content_middle_bold">刪除相簿內的 QR 碼截圖。</string>
+    <string name="tokens__gallery_advice_content_last">如果有人截取了這張 QR 碼截圖，他們就能取得您的 2FA 代碼使用這項服務。</string>
+    <string name="tokens__request_icon_page_title">申請圖示</string>
+    <string name="tokens__request_icon_social_title">在 Discord 上通知我們</string>
+    <string name="tokens__request_icon_social_link">登入我們的 Discord 伺服器</string>
+    <string name="tokens__request_icon_social_description">並讓使用者為所要求的圖示投票。</string>
+    <string name="tokens__request_icon_middle">或</string>
+    <string name="tokens__request_icon_provider_title">請通知服務提供者</string>
+    <string name="tokens__request_icon_provider_description">您可以使用社群媒體或電子郵件，與他們分享以下內容：</string>
+    <string name="tokens__request_icon_provider_message">嘿！我正在使用 2FAS 應用程式透過 2FA 登入您的服務。但是，您的圖示不見了！您可以在這裡提交您的圖示：https://2fas.com/yb</string>
+    <string name="tokens__request_icon_provider_message_link">https://2fas.com/yb</string>
+    <string name="tokens__request_icon_provider_footnote">別忘了標註公司的官方帳號！</string>
+    <string name="tokens__order_icon_description">在 2FAS 應用程式中找不到品牌圖示？</string>
+    <string name="tokens__order_icon_link">申請品牌圖示</string>
+    <string name="tokens__order_icon_title">申請品牌圖示</string>
+    <string name="tokens__order_menu_title">選擇要求方法</string>
+    <string name="tokens__order_menu_option_user">以使用者身分申請圖示</string>
+    <string name="tokens__order_menu_option_company">以公司身份提交圖示</string>
+    <!-- tokens__you_will_not_be_able_to_sign_in_to_your -->
+    <string name="tokens__sign_in_not_possible_title">只要開啟了 %1$s 的雙重認證，如果沒有此權杖，您將無法登入 %2$s 帳戶。</string>
+    <string name="voiceover__show_service_key">顯示金鑰</string>
+    <string name="voiceover__copy_service_key">複製金鑰</string>
+    <!-- voiceover__seconds_left -->
+    <string name="voiceover__seconds_left_counter_title">計數器，距離權杖變更還剩幾秒</string>
+    <string name="voiceover__delete_button">刪除按鈕</string>
+    <string name="voiceover__service_deleted">服務已刪除</string>
+    <!-- voiceover__hidden_secret_key_use_show button -->
+    <string name="voiceover__reveal_hidden_secret_key_button_title">此欄位包含隱藏的金鑰。如要顯示金鑰，請按一下「顯示」按鈕。只有在為鎖定畫面設定了應用程式 PIN 碼時，才會生效。</string>
+    <string name="voiceover__service_name">服務名稱：%s</string>
+    <string name="voiceover__additional_info">其他資訊：%s</string>
+    <string name="voiceover__token_tap_to_copy">權杖為 %s。按一下以複製。</string>
+    <string name="voiceover__edit">編輯 %s</string>
+    <string name="voiceover__service_label_with_name_and_color">帶有名稱 %1$s 和顏色 %2$s 的服務標籤</string>
+    <string name="voiceover__service_icon">%s 服务圖示</string>
+    <string name="voiceover__selected">已選定</string>
+    <string name="voiceover__not_selected">未選擇</string>
+    <string name="voiceover__badge_color">徽章顏色：%s</string>
+    <string name="voiceover__dismissing">取消中…</string>
+    <string name="voiceover__secret_hint">僅限數字 2 至 9 和字母，至少 4 個字元。</string>
+    <string name="voiceover__add_service">新增服務</string>
+    <string name="voiceover__add_group">新增群組</string>
+    <!-- voiceover__use_add_service_button -->
+    <string name="voiceover__use_add_service_button_title">按一下「新增服務」按鈕以新增服務</string>
+    <string name="voiceover__no_search_results">沒有搜尋結果</string>
+    <!-- voiceover__sort_by -->
+    <string name="voiceover__sort_by_title">使用「排序方式」以設定服務排序</string>
+    <string name="voiceover__spinner">正在載入內容</string>
+    <string name="backup__incorrect_secret">無法備份權杖，因為「%s」金鑰包括無效字元。請從清單中刪除它，然後再試一次。</string>
+    <string name="backup__import">匯入</string>
+    <string name="backup__export">匯出</string>
+    <string name="backup__backup_disabled_title">2FAS 備份將會停用以保護其完整性</string>
+    <string name="backup__error_while_exporting_file">匯出檔案時發生錯誤</string>
+    <string name="backup__import_completed_successfuly">匯入成功</string>
+    <!-- camera__video_device_in_use_by_another_app -->
+    <string name="camera__camera_used_by_other_app_title">另一個應用程式正在使用相機。如果關閉其他應用程式無效，請重新啟動裝置。</string>
+    <!-- camera__video_device_unavailable_due_to_system_overload  -->
+    <string name="camera__camera_unavailable_title">由於系統超載，相機無法使用。請嘗試重新啟動裝置。</string>
+    <string name="camera__cant_initialize_camera_general">無法初始化相機，請嘗試重新啟動裝置。</string>
+    <string name="camera__cant_initialize_camera_split_view">無法在分割檢視模式下初始化相機。請以全螢幕開啟應用程式，然後再試一次。</string>
+    <string name="restore__how_to_restore">如何還原 2FAS 應用程式？</string>
+    <string name="restore__application_restoration">應用程式還原</string>
+    <!-- restore_if_you_forgotten -->
+    <string name="restore__reset_Pin_title">如果您忘記了 PIN 碼或想要重設 2FAS 應用程式，則必須重新安裝應用程式。</string>
+    <!-- restore_please_remember -->
+    <string name="restore__backup_advice">請注意：如果您沒有備份就重設本應用程式，您將失去對所有密碼的存取權，同時也將失去對所有受 2FA 保護的帳戶的存取權限。</string>
+    <!-- restore_if_you_have_backup -->
+    <string name="restore__backup_title">如果您有備份，不用緊張，您可以嘗試還原所有代碼。</string>
+    <string name="backup__cloud_backup">雲端備份</string>
+    <string name="backup__icloud_sync">iCloud 同步</string>
+    <string name="backup__section_description">建議：iCloud 同步可以在裝置遺失或損壞的情況下，將您的令牌安全地儲存在 Apple iCloud。請保持其開啟。</string>
+    <string name="backup__file_backup">檔案備份</string>
+    <!-- backup__use_file_backup_for -->
+    <string name="backup__file_backup_offline_title">使用檔案備份離線備份權杖。</string>
+    <string name="backup__backup_removal">刪除備份</string>
+    <string name="backup__delete_2fas_backup">刪除 2FAS 備份</string>
+    <string name="backup__warning_introduction">警告！如果刪除 2FAS 備份，您也會刪除與此帳戶同步的其他裝置上的所有權杖。為保留其他裝置上的權杖，請確保在刪除前已關閉 2FAS 備份。</string>
+    <!-- backup__i_want_to_delete -->
+    <string name="backup__delete_title">我想刪除備份</string>
+    <string name="backup__export_to_backup_file">將備份匯出到文件</string>
+    <!-- backup__you_can_import_exported_file -->
+    <string name="backup__import_file_title">您可以使用 2FAS 應用程式將匯出的檔案匯入其他裝置</string>
+    <string name="backup__export_to_file">匯出至檔案</string>
+    <string name="backup__verify_pin">驗證 PIN 碼</string>
+    <string name="backup__save_file">儲存檔案</string>
+    <string name="backup__import_backup_file">匯入備份檔案</string>
+    <!-- backup__youre_goint_to_import_backup -->
+    <string name="backup__import_other_devices">您將匯入一個備份檔案，其中包括</string>
+    <string name="backup__import_file">匯入檔案</string>
+    <string name="backup__choose_antother_file">選擇其他檔案</string>
+    <string name="backup__no_new_services">沒有可匯入的內容</string>
+    <string name="backup__file_error">檔案錯誤！</string>
+    <!-- backup__services_form_file_will_be_merged -->
+    <string name="backup__services_merge_title">文件中的服務將與您應用程式中的服務合併</string>
+    <string name="backup__no_new_services_error">此文件為空白，或其中的所有服務均已在應用程式中可用</string>
+    <string name="backup__update_required_to_import_title">您需要更新至最新版本的應用程式才能匯入此檔案的內容，您可以在 App Store 中找到最新版本。</string>
+    <string name="backup__cant_read_file_error">無法讀取此檔案，檔案可能已損壞，或嘗試存取時出錯。請選擇另一個檔案。</string>
+    <string name="backup__password">密碼</string>
+    <string name="backup__repeat_password">重複密碼</string>
+    <string name="backup__incorrect_character_error">包括不正確的字元，只能使用字母 A-Z、a-z、數字和特殊字元：-_/!#$%&amp;+*~@?=^.,\'(){}[]:;&lt;&gt;|</string>
+    <string name="backup__to_short_error">提供的短語太短 (最少 3 個字元)</string>
+    <string name="backup__passwords_dont_match">密碼不匹配</string>
+    <string name="backup__save_and_export">儲存並匯出</string>
+    <string name="backup__set_password_title">為增強備份檔案的保護，請設定密碼</string>
+    <string name="backup__enter_password_title">輸入密碼以繼續匯入過程</string>
+    <string name="backup__backup_file_password_title">為備份檔案設定密碼</string>
+    <string name="backup__incorrect_password">密碼錯誤</string>
+    <!-- %d - number -->
+    <string name="backup__new_services">%d 新服務</string>
+    <!-- %d - number -->
+    <string name="backup__services_imported_count">從檔案匯入了 %d 個服務</string>
+    <!-- backup__user_has_icloud_problem -->
+    <string name="backup__icloud_problem">iCloud 發生問題，請檢查系統設定。</string>
+    <!-- backup__encrypted_unsupported -->
+    <string name="backup__encrypted_files_not_supported">此文件已加密，我們僅支援未加密的檔案。</string>
+    <string name="tokens__copy_token">複製權杖</string>
+    <!-- tokens__i_want_to_delete_this_servie -->
+    <string name="tokens__i_want_to_delete_this_token">是，我想刪除此服務</string>
+    <string name="color__neutral">無色</string>
+    <string name="color__light_blue">淺藍色</string>
+    <string name="color__indigo">靛藍色</string>
+    <string name="color__purple">紫色</string>
+    <string name="color__turquoise">綠松色</string>
+    <string name="color__green">綠色</string>
+    <string name="color__red">紅色</string>
+    <string name="color__orange">橙色</string>
+    <string name="color__yellow">黃色</string>
+    <string name="settings__knowledge">了解</string>
+    <string name="settings__support_and_share">支援與分享</string>
+    <string name="settings__tell_a_friend">推薦給朋友</string>
+    <string name="settings__write_a_review">撰寫評論</string>
+    <string name="settings__about">關於</string>
+    <string name="settings__privacy_policy">隱私權政策</string>
+    <string name="settings__terms_of_service">服務條款</string>
+    <string name="settings__version">應用程式版本 %s</string>
+    <string name="settings__no_limit">無限制</string>
+    <string name="settings__pin_code">PIN 碼</string>
+    <string name="settings__app_security">應用程式安全</string>
+    <string name="settings__app_blocking">鎖定設定</string>
+    <string name="settings__face_id">Face ID</string>
+    <string name="settings__touch_id">Touch ID</string>
+    <!-- settings__how_many_attempts_header -->
+    <string name="settings__too_many_attempts_header">在嘗試 X 次失敗後阻止連線：</string>
+    <string name="settings__how_many_attempts_footer">在應用程式被鎖定之前，選擇最大允許的連續失敗嘗試次數（鎖定時間可在下方變更）。</string>
+    <string name="settings__block_for">鎖定時間</string>
+    <string name="settings__3_minutes">3 分鐘</string>
+    <string name="settings__5_minutes">5 分鐘</string>
+    <string name="settings__10_minutes">10 分鐘</string>
+    <string name="settings__limit_of_trials">最大失敗嘗試次數</string>
+    <string name="settings__pin_4_digits">4 位數字</string>
+    <string name="settings__pin_6_digits">6 位數字</string>
+    <string name="settings__biometric_authentication">生物辨識認證</string>
+    <string name="settings__donations">捐贈</string>
+    <string name="settings__donate_twofas">捐贈 2FAS</string>
+    <string name="new_version__new_version_title">新版本</string>
+    <string name="new_version__new_version_message_ios">新版 2FAS 已在 App Store 上架。請立即更新！</string>
+    <string name="new_version__update_action">立即更新</string>
+    <!-- new_version__skip_action -->
+    <string name="new_version__skip_title">跳過此版本</string>
+    <!-- new_version__later_action -->
+    <string name="new_version__update_later">稍後更新</string>
+    <string name="browser__browser_extension">瀏覽器擴充功能</string>
+    <string name="browser__info_title">2FAS 瀏覽器擴充功能</string>
+    <string name="browser__info_description_first">在電腦上安裝 2FAS 瀏覽器擴充功能</string>
+    <string name="browser__info_description_second">與 2FAS 應用程式配對</string>
+    <string name="browser__more_info">更多資訊：</string>
+    <string name="browser__more_info_link_title">2fas.com/be</string>
+    <string name="browser__pair_with_web_browser">與網路瀏覽器配對</string>
+    <string name="browser__more_info_link">https://www.2fas.com/be</string>
+    <string name="browser__pairing_successful_title">配對成功！</string>
+    <string name="browser__pairing_successful_description">每當您使用此瀏覽器登入您的線上服務時，2FAS 都會向您推播通知。您將不再需要在每次使用時重新輸入權杖。</string>
+    <string name="browser__pairing_failed_title">配對失敗 :(</string>
+    <string name="browser__pairing_failed_description">無法辨別此 QR 碼，2FAS 無法將此裝置與瀏覽器擴充功能配對。請再試一次。</string>
+    <!-- browser__pairing_already_paired_title -->
+    <string name="browser__already_paired_title">已配對！</string>
+    <!-- browser__pairing_already_paired_description -->
+    <string name="browser__already_paired_description">此瀏覽器擴充功能已與此裝置配對。</string>
+    <string name="browser__contact_support">聯絡支援人員</string>
+    <string name="browser__pairing_with_browser">與瀏覽器配對</string>
+    <!-- browser__paired_devices -->
+    <string name="browser__paired_devices_browser_title">已配對裝置（網路瀏覽器）</string>
+    <string name="browser__add_new">新增新內容</string>
+    <!-- browser__this_device -->
+    <string name="browser__this_device_name">裝置暱稱</string>
+    <string name="browser__device_name">裝置暱稱</string>
+    <string name="browser__name">名稱</string>
+    <string name="browser__this_device_footer">此暱稱將幫助您在與 2FAS 瀏覽器擴充功能配對的其他裝置中識別此設備</string>
+    <string name="browser__browser_extension_settings">瀏覽器擴充功能設定</string>
+    <string name="browser__unkown_name">&lt;UNKOWN_NAME&gt;</string>
+    <string name="browser__request_source_description">%1$s 為 %2$s 申請了一個 2FA 權杖。請選擇要授權並儲存到此網域的服務。</string>
+    <string name="browser__request">瀏覽器請求</string>
+    <!-- browser__code_success -->
+    <string name="browser__code_success_title">權杖已成功傳送！</string>
+    <string name="browser__code_failure">發送驗證碼時發生錯誤：%s</string>
+    <string name="browser__deleting_paired_device_title">刪除已配對裝置</string>
+    <string name="browser__deleting_paired_device_content">您確定要刪除已配對的裝置嗎？</string>
+    <string name="browser__pairing_date">配對日期</string>
+    <string name="browser__forget_this_browser">忘記此網路瀏覽器</string>
+    <!-- browser__service_is_paired_list_description -->
+    <string name="browser__paired_domains_list_title">配對網域清單。</string>
+    <string name="browser__deleting_extension_pairing_title">移除網域？</string>
+    <string name="browser__deleting_extension_pairing_content">下次使用瀏覽器擴充功能登入 %s 時，會再次要求您配對此網域。</string>
+    <string name="browser__push_notifications_title">訊息推播通知</string>
+    <string name="browser__push_notifications_content">如要存取瀏覽器擴充功能等功能，應用程式需要存取推播通知。您可以隨時在「系統設定」中變更此設定。</string>
+    <string name="browser__request_expired">申請已過期</string>
+    <string name="browser__2fa_token_request_title">2FA 權杖要求</string>
+    <!-- ADD A SPACE AT THE END! -->
+    <string name="browser__2fa_token_request_content">您想分享 2FA 權杖至</string>
+    <string name="notifications__no_notifications">沒有通知</string>
+    <string name="CFBundleSpokenName">2 F A S</string>
+    <string name="commons__2fas_toolbar">2FAS</string>
+    <string name="backup__google_drive_not_available">無法使用 Google Drive</string>
+    <string name="backup__google_drive_disabled_title">使用者已停用 Google Drive</string>
+    <string name="backup__update_required_to_import_title_2">您需要更新至最新版本的應用程式才能匯入此檔案的內容，您可以在 Google Store 中找到最新版本。</string>
+    <string name="tokens__qr_code_leads_to_google_store">此 QR 碼將帶您前往 Google Store</string>
+    <string name="introduction__page_4_content_android">您的權杖透過裝置離線儲存，所以記得備份你的服務！使用 Google Drive 同步和 PIN 碼來防止未經授權的存取和裝置損壞。</string>
+    <string name="new_version__new_version_message_android">新版 2FAS 已在 Google Store 上架。請立即更新！</string>
+    <string name="security_error_no_match">PIN 碼不一致！請再試一次。</string>
+    <string name="settings_developer_options">開發人員選項</string>
+    <string name="settings__external_import">匯入權杖</string>
+    <string name="settings__browser_extension_result_toolbar_title">配對結果</string>
+    <string name="tokens__caution">注意</string>
+    <string name="tokens__qr_point_and_scan_again">將相機對準正確的 QR 碼並再次掃描。</string>
+    <string name="tokens__service_unsaved_changes">您要放棄變更嗎？</string>
+    <string name="tokens__service_unsaved_changes_title">未儲存的變更</string>
+    <string name="tokens__service_key_invalid_format">金鑰格式無效</string>
+    <string name="intent_error_no_gallery_app">系統錯誤！沒有系統相簿應用程式。</string>
+    <string name="gdrive_permission_title">Google Drive 權限</string>
+    <string name="gdrive_permission_msg">我們需要 Google Drive 權限才能將備份檔案儲存在應用程式資料中。</string>
+    <string name="gdrive_internet_title">需要網路連線</string>
+    <string name="gdrive_internet_msg">如果要與 Google 同步，您需要啟用網路連線。</string>
+    <string name="gdrive_wipe_internet_msg">如要撤銷 Google Drive 的存取權，您需要啟用網路連線。</string>
+    <string name="backup_explanation_msg">自動將您的備份檔案儲存並同步到您的Google Drive的隱藏資料夾中，只有 2FAS 應用程式才能存取該資料夾。</string>
+    <string name="backup_error_unknown">備份同步期間發生錯誤，請在幾分鐘後重新啟動應用程式，並再試一次。</string>
+    <string name="backup_error_encrypt_unknown">備份加密時發生錯誤，請重新設定密碼。</string>
+    <string name="backup_error_decrypt_unknown">備份解密時發生錯誤，請重新設定密碼。</string>
+    <string name="backup__google_drive_problem_title">iCloud 發生問題，請檢查系統設定。</string>
+    <string name="backup_error_auth">您的 Google Drive 帳戶權限有問題。請嘗試開啟和關閉同步功能。</string>
+    <string name="backup_error_no_password">您的備份已受密碼保護，請開啟並輸入密碼。</string>
+    <string name="backup_error_wrong_password">您的備份已受密碼保護，但提供的密碼不正確。請開啟備份並輸入密碼。</string>
+    <string name="customization_service_assignment">服務分配</string>
+    <string name="customization_personalization">個人化</string>
+    <string name="customization_change_brand">變更品牌</string>
+    <string name="customization_advanced">進階</string>
+    <string name="customization_request_icon">申請圖示</string>
+    <string name="customization_edit_label">編輯標籤</string>
+    <string name="groups_delete_msg">您確定要刪除該群組嗎？</string>
+    <string name="export_backup_title">您的備份檔案已準備好匯出</string>
+    <string name="export_backup_msg">匯出此文件以安全備份您的 2FAS 權杖，稍後您可以使用 2FAS 應用程式將其匯入本裝置或其他裝置。</string>
+    <string name="export_backup_pass">匯出沒有密碼的檔案\n（不建議）</string>
+    <string name="import_backup_msg2">該檔案將與應用程式的服務清單同步。</string>
+    <string name="backup_notice_later">下次再說</string>
+    <string name="backup_notice_cta">開啟</string>
+    <string name="widgets_empty_msg">未新增服務</string>
+    <string name="backup__section_description_google">建議：Google Drive 同步可以在裝置遺失或損壞的情況下，將您的權杖安全地儲存在 Google Drive 中。請保持開啟同步。</string>
+    <string name="backup_turn_off_title">關閉 Google Drive 同步功能？</string>
+    <string name="backup_turn_off_msg1">2FA 權杖將保留在此裝置和 Google Drive 上，但不會同步。您也將從 Google 帳戶中登出。</string>
+    <string name="backup_turn_off_msg2">請記住，如果此裝置遺失或損壞，或應用程式被刪除，您可能無法還原權杖，也無法存取由 2FA 保護的線上帳戶。</string>
+    <string name="backup_settings_password_set_subtitle">使用自訂密碼保護 Google Drive 備份檔案。</string>
+    <string name="backup_settings_password_remove_title">刪除密碼</string>
+    <string name="backup_settings_password_remove_subtitle">刪除 Google Drive 備份檔案的密碼</string>
+    <string name="backup_settings_account_title">Google 帳戶</string>
+    <string name="backup_settings_sync_title">上次同步</string>
+    <string name="browser_extension_result_success_description">每當您使用此瀏覽器登入您的線上服務時，2FAS都會向您推播通知。您將不再需要在每次使用時重新輸入權杖。</string>
+    <string name="browser_extension_browser_dialog">瀏覽器名稱</string>
+    <string name="biometric_dialog_auth_title">身份驗證</string>
+    <string name="biometric_dialog_auth_subtitle">使用您的生物辨識認證</string>
+    <string name="about_licenses">開放源碼授權</string>
+    <string name="externalimport_description">您可以從不同的應用程式將權杖匯入 2FAS。請先從清單中選擇一個應用，然後按照說明操作。</string>
+    <string name="externalimport_select_app">選擇應用程式</string>
+    <string name="externalimport_google_authenticator">Google Authenticator</string>
+    <string name="externalimport_aegis">Aegis</string>
+    <string name="externalimport_raivo">Raivo OTP</string>
+    <string name="android__app_name">2FAS 身份驗證器</string>
+    <string name="commons__yes">是</string>
+    <string name="commons__no">否</string>
+    <string name="commons__search">搜尋</string>
+    <string name="errors__no_app">沒有支援此連結的應用程式</string>
+    <string name="permissions__camera_permission">相機權限</string>
+    <string name="permissions__camera_permission_description">需要相機權限才能掃描 QR 碼。如果您想使用此功能，請前往應用程式資訊和權限，並啟用相機權限。</string>
+    <string name="security__disable_pin">停用 PIN 碼</string>
+    <string name="security__enter_your_new_pin">請設定您的新 %s PIN 碼</string>
+    <string name="security__pin_error_incorrect">PIN 碼不正確！請再試一次。</string>
+    <string name="settings__biometrics">生物辨識</string>
+    <string name="settings__support">2FAS 支援</string>
+    <string name="settings__developer">開發人員選項</string>
+    <string name="settings__option_fingerprint">生物辨識鎖定</string>
+    <string name="settings__option_theme">佈景主題</string>
+    <string name="settings__theme_option_auto">自動</string>
+    <string name="settings__theme_option_auto_system">自動 — 跟隨系統設定</string>
+    <string name="settings__theme_option_dark">深色</string>
+    <string name="settings__theme_option_light">淺色</string>
+    <string name="tokens__copied_clipboard">權杖已複製至剪貼簿！</string>
+    <string name="tokens__next_copied_clipboard">下一個權杖已複製至剪貼簿！</string>
+    <string name="tokens__do_you_really_want_to_remove_all_devices">您想永久刪除此 2FA 服務嗎？</string>
+    <string name="tokens__fab_addmanually">手動新增</string>
+    <string name="tokens__qr_does_not_work">此 QR 碼為無效！</string>
+    <!-- Could not read QR code from the image! -->
+    <string name="tokens__qr_read_image_failed">無法讀取圖片中的 QR 碼！</string>
+    <string name="tokens__qr_read_image_try_again">嘗試選擇不同的圖片。</string>
+    <string name="tokens__remove_it_forever">永久刪除服務</string>
+    <!-- Service could not be added, Service Key is invalid. Try again. -->
+    <string name="tokens__service_add_error">由於金鑰無效，無法新增服務。請再試一次。</string>
+    <!-- A service with this Service Key already exists. Do you want to override it? -->
+    <string name="tokens__service_already_exists">使用此金鑰的服務已存在。您想覆寫它嗎？</string>
+    <string name="tokens__service_key_invalid_characters">金鑰包括無效的字元</string>
+    <string name="tokens__show_service_key">顯示金鑰</string>
+    <!-- Your Service Key is protected. Please add PIN or Fingerprint lock in order to see it. -->
+    <string name="tokens__show_service_key_setup_lock">您的金鑰已受到保護。請新增 PIN 碼或指紋鎖才能檢視。</string>
+    <string name="tokens__tokens_list_is_empty">服務清單為空白</string>
+    <string name="tokens__use_plus_button_to_add_tokens">按一下「+」按鈕以新增服務</string>
+    <string name="tokens__you_will_not_be_able_to_sign_in_to_your">只要啟用了 %1$s 的雙重認證，沒有此權杖就無法登入 %2$s 帳戶。\n\n您將無法從 2FAS 資源回收筒還原此權杖。</string>
+    <string name="import_ga_success">已成功匯入服務！</string>
+    <!-- You need active Internet connection in order to sync your backup. Please turn on your network connection and try again. -->
+    <string name="backup_error_network">您需要有效的網路連線才能同步備份，請開啟網路連線並再試一次。</string>
+    <string name="update_app_title">更新應用程式</string>
+    <!-- Please update to the newest 2FAS version, to get all features and maintain high security level. -->
+    <string name="update_app_msg">請更新至最新的 2FAS 版本，以取得所有功能並維持較高的安全等級。</string>
+    <string name="delete_service_title">您正在刪除</string>
+    <!-- from your 2FAS service list.\n\nRemember, as long as you have second factor authentication turned on, you will not log in to %s account without this token. -->
+    <string name="delete_service_msg">從 2FAS 服務清單中刪除。\n\n請記住，只要您開啟了雙重認證，沒有此權杖就無法登入 %s 帳戶。</string>
+    <string name="delete_service_cta">刪除</string>
+    <string name="export_backup_cta">匯出</string>
+    <string name="export_backup_share_cta">分享</string>
+    <string name="import_backup_title">從檔案匯入備份</string>
+    <string name="import_backup_msg1">您將透過以下命令匯入備份檔案</string>
+    <string name="import_backup_cta">匯入</string>
+    <string name="widgets_warning_msg">在小工具中顯示的權杖不受您的 PIN 碼保護。\n\n您確定要在小工具中顯示您的權杖嗎？</string>
+    <string name="widgets_warning_title">警告！</string>
+    <string name="widgets_warning_cta">是的，我確定</string>
+    <string name="backup_notice_title">2FAS 備份</string>
+    <string name="backup_notice_msg">啟用 2FAS 備份。在重置或遺失手機的情況下，您可以還原所有令牌。</string>
+    <string name="brand_empty_msg">抱歉，未找到品牌</string>
+    <!-- Select which services will be visible on widget: -->
+    <string name="widgets_select_msg">選擇在小工具上顯示的服務：</string>
+    <string name="backup_turn_off_cta">停用同步</string>
+    <string name="backup_turn_off_cancel">取消</string>
+    <string name="backup_settings_password_set_title">設定密碼</string>
+    <string name="backup_settings_delete_title">刪除 Google Drive 上的備份檔案</string>
+    <!-- If you delete this file from your Google Drive, synchronization on all synchronized devices will be disabled and tokens will remain only on this and other devices via local storage. -->
+    <string name="backup_settings_delete_subtitle">如果刪除 Google Drive 上的備份檔案，所有同步裝置上的同步將被停用，權杖只能透過本機儲存保留在本裝置和其他裝置上。</string>
+    <string name="browser__result_error_browser_paired">您的 2FAS 應用程式已與此瀏覽器配對。</string>
+    <!-- Scan QR code again -->
+    <string name="browser__result_error_cta">再次掃描 QR 碼</string>
+    <string name="browser__scan_error_dialog_title">錯誤</string>
+    <!-- Scanned QR code has unsupported format. Please try again. -->
+    <string name="browser__scan_error_dialog_msg_invalid_code">掃描的 QR 碼格式不支援，請再試一次。</string>
+    <string name="browser__scan_error_dialog_msg_unknown">掃描 QR 碼時發生未知錯誤，請再試一次。</string>
+    <string name="biometric_dialog_auth_cancel">使用 PIN 碼</string>
+    <string name="biometric_dialog_setup_title">啟用身份驗證</string>
+    <string name="biometric_dialog_setup_cancel">取消</string>
+    <!-- To enable Biometric Lock you need to enable and set a PIN Code. -->
+    <string name="settings__option_fingerprint_description">如要啟用生物辨識鎖定，您需要啟用並設定 PIN 碼。</string>
+    <string name="settings__block_for_footer">選擇鎖定應用程式的時間。</string>
+    <string name="error__out_of_disk_space">看起來您的磁碟空間不足，或者過去發生的類似事件損壞了資料庫。</string>
+    <string name="error__cloud_backup_newer_version">雲端備份已遷移至新版本，請更新應用程式。</string>
+    <string name="error__cloud_backup_encrypted_not_supported">雲端備份已加密，請更新應用程式以支援此功能。</string>
+    <string name="extension__continue_to_app">繼續前往應用程式</string>
+    <string name="extension__cancel">取消</string>
+    <string name="extension__authorize">授權</string>
+    <string name="extension__dismiss">取消</string>
+    <string name="extension__request_sent">要求已傳送</string>
+    <string name="extension__send_question_title">傳送權杖？</string>
+    <string name="extension__send_question_content">%1$s 為 %2$s 申請了 2FAS 權杖</string>
+    <string name="extension__error_while_sending">傳送權杖時發生錯誤</string>
+    <string name="extension__not_paired_title">此網站未配對</string>
+    <string name="extension__not_paired_content">開啟應用程式並為此網域選擇一項服務</string>
+    <string name="extension__error_open_the_app">開啟應用程式，檢查瀏覽器擴充功能是否正確配對</string>
+    <string name="extension__error_no_internet">連線出現問題</string>
+    <string name="extension__try_again">請再試一次</string>
+    <string name="extension__error">錯誤</string>
+    <string name="extension__error_no_services">為了使瀏覽器擴充功能正常執行，請將服務新增至 2FAS 應用程式。</string>
+    <string name="extension__approve">同意</string>
+    <string name="extension__deny">拒絕</string>
+    <string name="settings__turn_pin_code_to_enable_faceid">啟用 PIN 碼和 Face ID 授權，以防止未經授權存取此裝置上的權杖。</string>
+    <string name="settings__turn_pin_code_to_enable_touchid">啟用 PIN 碼和 Touch ID 授權，以防止未經授權存取此裝置上的權杖。</string>
+    <string name="settings__send_logs_error_not_exists">提供的代碼不正確，請仔細檢查。</string>
+    <string name="settings__send_logs_error_expired">提供的代碼已過期，請聯絡官方團隊以取得新代碼。</string>
+    <string name="settings__send_logs_error_no_internet">網路未連線，請檢查連線並再試一次。</string>
+    <string name="settings__send_logs_error_server">我們的伺服器似乎出現了問題。如果問題仍然存在，請聯絡我們的支援團隊。</string>
+    <string name="settings__send_logs_error_title">作業失敗</string>
+    <string name="settings__send_logs_sent_title">已傳送的日誌</string>
+    <string name="settings__send_logs_sent_description">感謝您的意見回饋，我們會盡快進行分析。</string>
+    <string name="commons__send">傳送</string>
+    <string name="settings__send_logs_title">傳送日誌</string>
+    <string name="settings__send_logs_description_link">由官方團隊提供的代碼已自動填入。是否傳送日誌？</string>
+    <string name="settings__send_logs_description_edit">請輸入或貼上由我們的官方支援團隊提供的代碼。</string>
+    <string name="settings__send_logs">傳送日誌</string>
+    <string name="settings__recommendation">試用這個來自 2FAS 的超棒的雙重認證應用程式吧！ https://2fas.com</string>
+    <string name="settings__acknowledgements">鳴謝</string>
+    <string name="introduction__import_external_app">從外部應用程式導入</string>
+    <plurals name="past_duration_seconds">
+        <item quantity="other">剛剛</item>
+    </plurals>
+    <plurals name="past_duration_minutes">
+        <item quantity="other">%d 分鐘前</item>
+    </plurals>
+    <plurals name="past_duration_hours">
+        <item quantity="other">%d 小時前</item>
+    </plurals>
+    <plurals name="past_duration_days">
+        <item quantity="other">%d 天前</item>
+    </plurals>
+    <plurals name="past_duration_weeks">
+        <item quantity="other">%d 週前</item>
+    </plurals>
+    <plurals name="past_duration_months">
+        <item quantity="other">%d 個月前</item>
+    </plurals>
+    <string name="commons__unknown_error">發生未知錯誤！請再試一次！</string>
+    <string name="backup__export_result_success">檔案已成功儲存！</string>
+    <string name="backup__share_result_failure">無法分享檔案！</string>
+    <string name="backup__enter_password_dialog_title">請輸入密碼</string>
+    <string name="backup__remove_password_msg">請輸入備份密碼以繼續執行移除作業。</string>
+    <string name="backup__revoke_google_access_msg">請輸入備份密碼以繼續撤銷對 Google 的存取權限。</string>
+    <string name="backup__synchronization_settings">同步設定</string>
+    <string name="backup__local_file_title">本機檔案</string>
+    <string name="backup__drive_title">Google Drive 同步</string>
+    <string name="backup__delete_file_title">從 Google Drive 刪除備份檔案？</string>
+    <string name="backup__delete_file_msg">Google 同步將會停用，您的權杖將保留在本裝置，但 2FAS 應用程式將從您在本裝置和其他同步裝置上的 Google 帳戶中登出。</string>
+    <string name="backup__sync_status_waiting">等待同步…</string>
+    <string name="backup__sync_status_progress">同步中…</string>
+    <string name="import_backup_msg1_encrypted">您將匯入一個加密的備份檔案。</string>
+    <string name="externalimport__choose_json_cta">選擇 JSON 檔案</string>
+    <string name="externalimport__aegis_msg">將您的帳戶從 Aegis 匯出到未加密的 JSON 檔案並使用「選擇 JSON 檔案」按鈕上傳。匯入成功後，請記得刪除該檔案。</string>
+    <string name="externalimport__raivo_msg">使用 Raivo 設定中的「將 OTP 匯出到 ZIP 檔案」選項，先儲存 ZIP 文件，然後解壓縮並按一下「選擇 JSON 檔案」按鈕以匯入 JSON 檔案。</string>
+    <string name="externalimport__no_tokens_msg">不過，沒有可以匯入的服務。</string>
+    <string name="commons__try_again">請再試一次</string>
+    <string name="commons__proceed">繼續</string>
+    <string name="externalimport__ga_title">從 Google Authenticator 應用程式匯入 2FA 權杖</string>
+    <string name="externalimport__aegis_title">從 Aegis 應用程式匯入 2FA 權杖</string>
+    <string name="externalimport__raivo_title">從 Raivo 應用程式匯入 2FA 權杖</string>
+    <string name="externalimport__ga_success_msg">此 QR 碼可從 Google Authenticator 匯入令牌。</string>
+    <string name="externalimport__aegis_success_msg">此 JSON 檔案可從 Aegis 匯入令牌。</string>
+    <string name="externalimport__raivo_success_msg">此 JSON 檔案可從 Raivo 匯入令牌。</string>
+    <string name="externalimport__read_error">無法讀取任何權杖，請嘗試選擇其他檔案。</string>
+    <string name="settings__gd_sync_info">Google Drive 同步提醒</string>
+    <string name="settings__gd_sync_disable_confirm">您確定嗎？如果沒有 Google Drive 同步，遺失或重設手機後將無法還厡權杖！</string>
+    <string name="extension__code_sent_msg">驗證碼傳送成功</string>
+    <string name="extension__code_sent_error_msg">傳送驗證碼時發生錯誤</string>
+    <string name="tokens__add_service_title">新增新服務</string>
+    <string name="tokens__customize_service_title">自訂服務</string>
+    <string name="extension__services_suggested_header">建議</string>
+    <string name="extension__services_all_header">所有服務</string>
+    <string name="extension__services_other_header">其他服務</string>
+    <string name="settings__ssl_error_title">SSL 錯誤</string>
+    <string name="settings__ssl_error_description">發生 SSL 錯誤，無法與伺服器建立安全連線。請確保您使用的是最新版本的應用程式，或嘗試更換網路。</string>
+    <string name="backup__import_error_file_size">您嘗試匯入的檔案太大，大小限制為 10 MB。</string>
+    <string name="backup__import_error_file_invalid">您嘗試匯入的檔案無效或已損壞，請選擇其他文件。</string>
+    <string name="appearance__toggle_active_search">主動搜尋</string>
+    <string name="appearance__active_search_description">啟動時打開搜尋框</string>
+    <string name="widgets__expires_in">有效期：</string>
+    <string name="widgets__settings">小工具設定</string>
+    <string name="errors__input_integer_number">只能輸入整數</string>
+    <string name="errors__input_number">只能輸入數字</string>
+    <string name="errors__input_empty">輸入內容為空白，請輸入內容</string>
+    <string name="errors__input_too_long">輸入的長度過長。限制：%d</string>
+    <string name="commons__best_match">最佳匹配</string>
+    <string name="settings__enable_crashlytics">發送匿名崩潰報告</string>
+    <string name="settings__enable_crashlytics_description">發送匿名崩潰報告以協助 2FAS 識別和解決應用程式中的問題（需要重新啟動應用程式）。</string>
+    <string name="tokens__manage_list">管理清單</string>
+    <string name="settings__appearance">外觀</string>
+    <string name="settings__show_next_token_desc">在目前權杖即將過期時，顯示下一個權杖。</string>
+    <string name="settings__list_style">清單樣式</string>
+    <string name="backup__reminder_msg">Google Drive 未同步</string>
+    <string name="backup__reminder_cta">前往備份設定</string>
+    <string name="settings__list_style_option_default">預設</string>
+    <string name="settings__list_style_option_compact">緊湊</string>
+    <string name="externalimport_lastpass">LastPass</string>
+    <string name="externalimport__lastpass_msg">將您的帳戶從 LastPass 匯出到未加密的 JSON 檔案並使用「選擇 JSON 檔案」按鈕上傳。匯入成功後，請記得刪除該檔案。</string>
+    <string name="settings__about_crash_optout_title">崩潰報告</string>
+    <string name="externalimport__lastpass_title">從 LastPass 應用程式匯入 2FA 權杖</string>
+    <string name="externalimport__lastpass_success_msg">此 JSON 檔案可從 LastPass 匯入令牌。</string>
+    <string name="externalimport__info_lastpass_title">從 LastPass 匯入權杖</string>
+    <string name="externalimport__info_aegis_title">從 Aegis 匯入權杖</string>
+    <string name="externalimport__info_raivo_title">從 Raivo OTP 匯入權杖</string>
+    <string name="externalimport__info_google_authenticator_title">從 Google Authenticator 匯入權杖</string>
+    <!-- Counter eg.: "25s" -->
+    <string name="time_unit_seconds_short">秒</string>
+    <string name="tokens__add_title">將服務與 2FAS 配對</string>
+    <string name="tokens__add_description">將相機對準螢幕捕捉QR碼。</string>
+    <string name="tokens__add_other_methods">其他方法</string>
+    <string name="tokens__add_enter_manual">手動輸入金鑰</string>
+    <string name="tokens__add_from_gallery">上傳帶有 QR 碼的截圖</string>
+    <string name="tokens__add_success_title">即將完成！</string>
+    <string name="tokens__add_success_description">如要完成與服務的配對，您需要重新輸入此權杖。</string>
+    <string name="tokens__add_manual_title">將服務與 2FAS 配對</string>
+    <string name="tokens__add_manual_description">輸入服務名稱和金鑰。</string>
+    <string name="tokens__add_manual_service_name">服務名稱</string>
+    <string name="tokens__add_manual_service_key">金鑰</string>
+    <string name="tokens__add_manual_other">其他設定</string>
+    <string name="tokens__add_manual_other_optional">（可選）</string>
+    <string name="tokens__add_manual_done_cta">新增服務</string>
+    <string name="tokens__add_manual_help_cta">不知道該怎麼做？點選尋求協助</string>
+    <string name="tokens__add_manual_advanced">進階權杖設定</string>
+    <string name="tokens__add_manual_additional_info">其他資訊</string>
+    <string name="tokens__add_manual_advanced_description">不建議變更預設權杖設定。只有在您的 2FA 提供者要求且您有明確指示的情況下，才可以進行變更。</string>
+    <string name="settings__option_screenshots_description">允許應用程式螢幕截圖 5 分鐘。</string>
+    <string name="settings__option_screenshots">允許螢幕截圖</string>
+    <string name="settings__option_screenshots_confirm_title">允許應用程式螢幕截圖？</string>
+    <string name="settings__option_screenshots_confirm_description">你確定嗎？此選項可讓您截圖和錄製應用程式內的任何螢幕畫面。不過，這也會允許任何外部嘗試捕捉應用程式中的螢幕畫面。\n基於安全考慮，此選項將在 5 分鐘後自動關閉。</string>
+    <string name="social__social_media">社群媒體連結</string>
+    <string name="social__discord">Discord</string>
+    <string name="social__youtube">YouTube</string>
+    <string name="social__twitter">X（原稱 Twitter）</string>
+    <string name="social__github">GitHub</string>
+    <string name="social__linkedin">LinkedIn</string>
+    <string name="social__reddit">Reddit</string>
+    <string name="social__facebook">Facebook</string>
+    <string name="settings__hide_tokens_title">隱藏權杖</string>
+    <string name="settings__hide_tokens_description">輕按即可顯示權杖</string>
+    <string name="browser__pair_manually_cta">手動配對</string>
+    <string name="browser__pair_manually_hint">配對代碼</string>
+    <string name="externalimport__info_authenticatorpro_title">從 Authenticator Pro 匯入權杖</string>
+    <string name="externalimport__authenticatorpro_success_msg">此文字檔案可從 Authenticator Pro 匯入權杖。</string>
+    <string name="externalimport__authenticatorpro_title">從 Authenticator Pro 應用程式匯入 2FA 權杖</string>
+    <string name="externalimport__authenticatorpro_msg">將您的帳戶從 Authenticator Pro 匯出到未加密的文字文件，然後使用「選擇文字檔案」按鈕上傳。匯入成功後，請記得刪除該檔案。</string>
+    <string name="externalimport__authenticatorpro">Stratum (Authenticator Pro)</string>
+    <string name="externalimport__choose_txt_cta">選擇文字檔案</string>
+    <string name="fingerprint__biometric_invalidated">由於系統指紋設定變更，生物辨識登入已停用</string>
+    <string name="tokens__last_pass_import">從 LastPass 應用程式匯入 2FA 權杖</string>
+    <string name="tokens__last_pass_import_subtitle">此 QR 碼可從 LastPass 匯入權杖</string>
+    <string name="tokens__add_with_guide">引導我</string>
+    <string name="guides__select_title">瀏覽服務</string>
+    <string name="guides__select_description">選擇與 2FAS 應用程式配對的服務</string>
+    <string name="guides__select_provide_guide">您想為您的服務提供 2FA 指南嗎？</string>
+    <string name="guides__select_provide_guide_cta">立即申請</string>
+    <string name="color__pink">粉色</string>
+    <string name="color__brown">棕色</string>
+    <string name="tokens__other_methods_header">其他方法？</string>
+    <string name="tokens__camera_is_unavailable_app_permission">相機不可用。請在系統設定中檢查應用程式的存取權限。</string>
+    <!-- This key contains part of the tokens__camera_is_unavailable_app_permission key, which will be underlined in the app to look like a link to System Settings -->
+    <string name="tokens__camera_is_unavailable_app_permission_underline">系統設定</string>
+    <string name="commons__text_short_title">提供的文字過短（最少 %d 字元）</string>
+    <!-- This key should contain a part of the tokens__add_manual_advanced_description which is written in bold in the app -->
+    <string name="tokens__add_manual_advanced_description_highlight">不建議</string>
+    <string name="guides__guide_init_title">2FAS 指南</string>
+    <string name="guides__guide_title">%s 的 2FAS</string>
+    <string name="guides__guide_universal_title">通用 2FA 指南</string>
+    <string name="browser__save_choice">儲存我的選擇</string>
+    <string name="externalimport_andotp">andOTP</string>
+    <string name="externalimport__andotp_title">從 andOTP 應用程式匯入 2FA 權杖</string>
+    <string name="externalimport__andotp_success_msg">此 JSON 檔案可從 andOTP 匯入權杖。</string>
+    <string name="externalimport__info_andotp_title">從 andOTP 匯入權杖</string>
+    <string name="externalimport__andotp_msg">將您的帳戶從 andOTP 匯出到未加密的 JSON 檔案並使用「選擇 JSON 檔案」按鈕上傳。匯入成功後，請記得刪除該檔案。</string>
+    <string name="introduction__backup_description">下一步，系統會要求您選擇 Google Drive 帳戶，2FA 權杖將安全地儲存在該帳戶中。</string>
+    <string name="introduction__backup_take_risk_cta">我願意承擔風險，不會備份</string>
+    <string name="introduction__backup_success">Google Drive 同步已成功開啟！</string>
+    <string name="backup__import_invalid_version">此應用程式版本不支援您要匯入的備份檔案。應用程式只支援 %d 以下的備份格式版本，而您要匯入的檔案是 %d 版本。</string>
+    <string name="commons__pair">配對</string>
+    <string name="introduction__backup_icloud_title">安全同步和備份</string>
+    <!-- "**...**" means thar part between those asterisks will be in bold. -->
+    <string name="introduction__backup_icloud_description">2FAS 使用 iCloud 對您的 2FA 權杖進行安全備份和同步。 **加密**備份資料儲存在 iCloud 中，**只有 2FAS 應用程式**才能存取。此外，該功能還有助於在 iOS 裝置間**還原和同步**權杖。\n\n此功能預設為啟用，可隨時在套用的備份設定中停用。</string>
+    <string name="introduction__backup_icloud_cta">了解有關備份的更多資訊</string>
+    <string name="backup__enter_password_google_drive_msg1">看起來您的 Google Drive 備份檔案受到密碼保護，如果您想刪除 Google Drive 備份檔案，請輸入正確的密碼解鎖。</string>
+    <string name="backup__enter_password_google_drive_msg2">按一下這裡以了解更多</string>
+    <string name="settings__preferences">偏好設定</string>
+    <string name="settings__it_matters">重要提示</string>
+    <string name="settings__manage_tokens">管理權杖</string>
+    <string name="settings__info_footer">有了您的支持，我們才能開發新功能並不斷改進。謝謝您的支持！</string>
+    <string name="settings__trash_option">從資源回收筒找回</string>
+    <string name="periodic_notification_tips">很高興您加入 2FAS！🌟 請花一點時間在應用程式中發掘有用的秘訣與技巧 🛠️，以加強安全性 🔒.</string>
+    <string name="periodic_notification_backup">啟用 2FAS 備份與同步功能，確保即使遺失手機也不會被鎖住 - 只需輕輕一按，安心無憂！ 🔐📱</string>
+    <string name="periodic_notification_browser_extension">使用 2FAS 瀏覽器擴充套件加快登入速度！🚀立即下載，以獲得更快速、更方便的身份驗證。🌐✨</string>
+    <string name="periodic_notification_donate">感謝您對 2FAS 的支持！🌟 如果您覺得我們的應用程式對您有幫助，請考慮捐款幫助我們保護您在數位世界的安全。一分一毫都有幫助！🙏💙</string>
+    <!-- DO NOT TRANSLATE! -->
+    <string name="tokens__steam">STEAM</string>
+    <string name="widget__placeholder">佔位符</string>
+    <string name="widget__size_not_supported">不支援此尺寸</string>
+    <string name="widget__settings_description">選擇要在小工具上顯示的服務。如果沒有可用的服務，請確保您已在應用程式「設定」部分啟用小工具。</string>
+    <string name="widget__service_icon">服務圖示</string>
+    <string name="widget__not_enabled">2FAS 設定部分中未啟用小工具功能</string>
+    <string name="widget__not_enabled_no_services">2FAS 設定部分未啟用小工具功能，且應用程式中沒有可供選擇的服務</string>
+    <string name="widget__no_services">應用程式中沒有可供選擇的服務</string>
+    <string name="widget__select_service_intent_description">選擇您想要在 2FAS 小工具上顯示的服務</string>
+    <string name="widget__my_secured_account">我的安全帳戶</string>
+    <string name="widget__token">權杖</string>
+    <string name="watch__intro">2FAS watchOS 應用程式是 2FAS iOS 應用程式的配套程式。它會顯示使用 iCloud 同步備份的服務。\n\n如要快速存取，請將它們加入「常用服務」。\n\n請記得捐款，讓我們能進一步改善 2FAS 平台！</string>
+    <string name="tokens__hotp_not_supported">暫不支援 HOTP 服務</string>
+    <string name="tokens__favorite_services">常用服務</string>
+    <string name="security__enter_new_pin_short">輸入新的 PIN 碼</string>
+    <string name="security__repeat_new_pin_short">重複輸入新的 PIN 碼</string>
+    <string name="commons__success">成功</string>
+    <string name="security__enter_pin_short">請輸入 PIN 碼</string>
+    <string name="settings__sort_tokens">權杖排序</string>
+    <string name="appleWatch__installation_info_title">2FAS Apple Watch 應用程式安裝</string>
+    <string name="appleWatch__installation_first_step">透過 Watch 應用程式安裝 2FAS 身分驗證器</string>
+    <string name="appleWatch__installation_first_step_link">開啟 Watch 應用程式</string>
+    <string name="appleWatch__installation_second_step">確保您的 iCloud 同步已啟用</string>
+    <string name="appleWatch__installation_second_step_link">前往 2FAS 備份設定</string>
+    <string name="settings__apple_watch">Apple Watch</string>
+    <string name="widget__no_selected_services">按住並選擇服務以啟動小工具…</string>
+    <string name="widget__reveal_tokens_long_message">展示您的 2FAS 權杖 60 秒</string>
+    <string name="widget__reveal_tokens_short_message">顯示 60 秒</string>
+    <string name="settings__show_error_details">顯示錯誤詳細資訊</string>
+    <string name="tokens__show_qr_code">服務 QR 碼</string>
+    <string name="tokens__show_service_qr_setup_lock">您的服務受到保護，請新增 PIN 碼或指紋鎖以檢視 QR 碼。</string>
+    <string name="tokens__copy_uri">複製 URI</string>
+    <string name="backup__cloud_encrypted_user">iCloud 已使用自訂密碼加密，請輸入密碼並啟用同步。</string>
+    <string name="backup__cloud_encrypted_system">iCloud 使用系統金鑰加密，請確保您已啟用 iCloud 鑰匙圈。</string>
+    <string name="backup__synced">已同步</string>
+    <string name="backup__checking">檢查中…</string>
+    <string name="backup__sync_disabled">同步已停用。</string>
+    <string name="backup__sync_not_available">同步不可用：%s</string>
+    <string name="backup__watch_pairing_title">與 Apple Watch 配對</string>
+    <string name="backup__watch_pairing_description">您想將 Apple Watch 與您的 iCloud 備份配對嗎？請輸入裝置的名稱：</string>
+    <string name="backup__watch_pairing_default_name">Apple Watch</string>
+    <string name="backup__watch_pairing_action">配對裝置</string>
+    <string name="backup__watch_pairing_error">目前無法與手錶配對，請確保已啟用雲端備份並使用密碼同步。</string>
+    <string name="backup__cloud_error_title">雲端備份錯誤</string>
+    <string name="backup__cloud_error_missing_system_key_content">無法解密雲端備份，因為沒有系統金鑰。請檢查 iCloud 鑰匙圈同步是否已啟用且正常執行。</string>
+    <string name="backup__cloud_error_mismatch_key_content">無法解密雲端備份，因為它使用系統金鑰加密，而您使用的是自訂密碼。您想更換嗎？</string>
+    <string name="backup__cloud_error_new_version_content">無法與雲端備份同步，因為雲端備份已遷移至較新版本的應用程式。請更新應用程式以繼續使用雲端備份。</string>
+    <string name="backup__enter_cloud_backup_password_title">輸入雲端備份密碼</string>
+    <string name="backup__enter_password_description">iCloud 備份透過您的密碼加密。輸入密碼以啟用同步。</string>
+    <string name="backup__enter_password_failure">失敗！%s</string>
+    <string name="backup__enter_password_wrong_password">密碼錯誤！請再試一次。</string>
+    <string name="backup__migration_title">遷移雲端備份</string>
+    <string name="backup__migration_subtitle">不要關閉此應用程式！</string>
+    <string name="backup__migration_description">您的備份已透過系統金鑰進行加密，此金鑰將與您使用 iCloud 鑰匙圈的應用程式共用，請確保該選項已啟用。如您想使用自己的密碼，可以在遷移後在雲端備份設定中進行設定。</string>
+    <string name="commons__success_ex">成功！</string>
+    <string name="backup__encryption_type">加密類型</string>
+    <string name="backup__encryption_select">選擇加密類型</string>
+    <string name="backup__encryption_enter_password">輸入密碼</string>
+    <string name="backup__encryption_change_password">變更密碼</string>
+    <string name="backup__encryption_password_description">密碼用於加密您的資料。如果您遺失了密碼，您將無法從雲端備份中復原資料。</string>
+    <string name="backup__encryption_change_title">變更加密類型</string>
+    <string name="backup__encryption_method_footer">選擇系統或自訂密碼</string>
+    <string name="backup__manage_paired_watches_title">管理已配對的 Apple Watch</string>
+    <string name="backup__manage_paired_watches_footer">透過此雲端備份，您可以新增、刪除或重新命名 Apple Watch。</string>
+    <string name="backup__manage_paired_watches_rename_title">重新命名手錶</string>
+    <string name="backup__manage_paired_watches_rename_description">輸入新裝置名稱</string>
+    <string name="backup__manage_paired_watches_rename_action">重新命名</string>
+    <string name="backup__manage_paired_watches_title_short">管理手錶</string>
+    <string name="backup__manage_paired_watches_empty_list">清單為空白。請按一下「+」按鈕以配對手錶</string>
+    <string name="backup__manage_paired_watches_syncing">雲端備份正在同步…</string>
+    <string name="backup__watch_pair_title">配對 Apple Watch</string>
+    <string name="backup__watch_pair_description">在 iPhone/iPad 上的 2FAS Auth 應用程式內前往 2FAS 備份設定，進入「管理已配對的 Apple Watch 」選項（如果備份已同步，此選項將可見）。從該畫面掃描QR碼。</string>
+    <string name="backup__watch_pair_qr_error">產生 QR 碼時發生錯誤</string>
+    <string name="backup__cloud_switch_system_key">切換至系統金鑰</string>
+    <string name="backup__cloud_turn_backup_off">停用雲端備份</string>
+    <string name="commons__apply">套用</string>
+    <string name="backup__state">狀態：</string>
+    <string name="backup__check_password">檢查密碼</string>
+    <string name="backup__missing_system_key">缺少系統金鑰</string>
+    <string name="backup__system_key">系統金鑰</string>
+    <string name="backup__custom_password">自訂密碼</string>
+    <string name="commons__options_title">選項</string>
+    <string name="tokens__copy_secret">複製金鑰</string>
+    <string name="tokens__copy_link">複製 OTP 驗證連結</string>
+    <string name="notifications__link_copied">連結已複製</string>
+    <string name="tokens__qr_code_show">顯示服務 QR 碼</string>
+    <string name="tokens__qr_code_share">分享服務 QR 碼</string>
+</resources>


### PR DESCRIPTION
- Add complete zh-CN translation based on existing zh (Traditional Chinese)
- Include main strings.xml with 912 translated strings
- Add debug configuration for zh-CN locale
- Locale already configured in locales_config.xml

Resolves: Support for Simplified Chinese users