### PR TITLE
Add AMOLED theme

### DIFF
--- a/app/src/main/java/com/twofasapp/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/twofasapp/ui/main/MainActivity.kt
@@ -69,6 +69,7 @@ class MainActivity : AppCompatActivity(), AuthAware {
                         SelectedTheme.Auto -> (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
                         SelectedTheme.Light -> false
                         SelectedTheme.Dark -> true
+                        SelectedTheme.AmoledDark -> true
                     }
                 }
             ),
@@ -80,6 +81,7 @@ class MainActivity : AppCompatActivity(), AuthAware {
                         SelectedTheme.Auto -> (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
                         SelectedTheme.Light -> false
                         SelectedTheme.Dark -> true
+                        SelectedTheme.AmoledDark -> true
                     }
                 }
             ),
@@ -97,11 +99,16 @@ class MainActivity : AppCompatActivity(), AuthAware {
                 window.isNavigationBarContrastEnforced = false
             }
 
+            if (selectedTheme == SelectedTheme.AmoledDark) {
+                window.setBackgroundDrawable(android.graphics.drawable.ColorDrawable(android.graphics.Color.BLACK))
+            }
+
             CompositionLocalProvider(
                 LocalAppTheme provides when (selectedTheme) {
                     SelectedTheme.Auto -> AppTheme.Auto
                     SelectedTheme.Light -> AppTheme.Light
                     SelectedTheme.Dark -> AppTheme.Dark
+                    SelectedTheme.AmoledDark -> AppTheme.AmoledDark
                 },
                 LocalDynamicColors provides appSettings.dynamicColors,
             ) {

--- a/app/src/main/java/com/twofasapp/ui/main/StartActivity.kt
+++ b/app/src/main/java/com/twofasapp/ui/main/StartActivity.kt
@@ -44,6 +44,7 @@ class StartActivity : AppCompatActivity(), AuthAware {
                         SelectedTheme.Auto -> (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
                         SelectedTheme.Light -> false
                         SelectedTheme.Dark -> true
+                        SelectedTheme.AmoledDark -> true
                     }
                 }
             ),
@@ -55,6 +56,7 @@ class StartActivity : AppCompatActivity(), AuthAware {
                         SelectedTheme.Auto -> (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
                         SelectedTheme.Light -> false
                         SelectedTheme.Dark -> true
+                        SelectedTheme.AmoledDark -> true
                     }
                 }
             ),

--- a/core/common/src/main/java/com/twofasapp/common/domain/SelectedTheme.kt
+++ b/core/common/src/main/java/com/twofasapp/common/domain/SelectedTheme.kt
@@ -4,4 +4,5 @@ enum class SelectedTheme {
     Auto,
     Light,
     Dark,
+    AmoledDark,
 }

--- a/core/designsystem/src/main/java/com/twofasapp/designsystem/AppTheme.kt
+++ b/core/designsystem/src/main/java/com/twofasapp/designsystem/AppTheme.kt
@@ -17,6 +17,9 @@ import androidx.window.core.layout.WindowWidthSizeClass
 import com.twofasapp.designsystem.internal.OverriddenDarkColors
 import com.twofasapp.designsystem.internal.OverriddenLightColors
 import com.twofasapp.designsystem.internal.ThemeColors
+import com.twofasapp.designsystem.internal.backgroundAmoled
+import com.twofasapp.designsystem.internal.surfaceAmoled
+import com.twofasapp.designsystem.internal.surfaceVariantAmoled
 import com.twofasapp.designsystem.internal.onSurfacePrimaryDark
 import com.twofasapp.designsystem.internal.onSurfacePrimaryLight
 import com.twofasapp.designsystem.internal.onSurfaceSecondaryDark
@@ -40,7 +43,7 @@ val LocalThemeColors = staticCompositionLocalOf { ThemeColors() }
 val LocalDynamicColors = staticCompositionLocalOf { false }
 
 enum class AppTheme {
-    Auto, Light, Dark,
+    Auto, Light, Dark, AmoledDark,
 }
 
 @Composable
@@ -55,13 +58,25 @@ fun MainAppTheme(
         AppTheme.Auto -> isSystemInDarkTheme()
         AppTheme.Light -> false
         AppTheme.Dark -> true
+        AppTheme.AmoledDark -> true
     }
 
-    val colorScheme: ColorScheme = when {
+    var colorScheme: ColorScheme = when {
         isDynamicColorEnabled && isInDarkTheme && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> dynamicDarkColorScheme(LocalContext.current)
         isDynamicColorEnabled && !isInDarkTheme && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> dynamicLightColorScheme(LocalContext.current)
         isInDarkTheme -> OverriddenDarkColors
         else -> OverriddenLightColors
+    }
+
+    if (LocalAppTheme.current == AppTheme.AmoledDark) {
+         colorScheme = colorScheme.copy(
+            background = backgroundAmoled,
+            onBackground = onSurfacePrimaryDark,
+            surface = surfaceAmoled,
+            onSurface = onSurfacePrimaryDark,
+            surfaceVariant = surfaceVariantAmoled,
+            onSurfaceVariant = onSurfacePrimaryDark,
+        )
     }
 
     val themeColors = ThemeColors(

--- a/core/designsystem/src/main/java/com/twofasapp/designsystem/AppThemeState.kt
+++ b/core/designsystem/src/main/java/com/twofasapp/designsystem/AppThemeState.kt
@@ -10,6 +10,7 @@ object AppThemeState {
         val mode = when (theme) {
             SelectedTheme.Light -> AppCompatDelegate.MODE_NIGHT_NO
             SelectedTheme.Dark -> AppCompatDelegate.MODE_NIGHT_YES
+            SelectedTheme.AmoledDark -> AppCompatDelegate.MODE_NIGHT_YES
             SelectedTheme.Auto -> {
                 when {
                     Build.VERSION.SDK_INT >= 28 -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM

--- a/core/designsystem/src/main/java/com/twofasapp/designsystem/internal/ColorPrimitives.kt
+++ b/core/designsystem/src/main/java/com/twofasapp/designsystem/internal/ColorPrimitives.kt
@@ -33,6 +33,11 @@ internal val serviceBackgroundWithGroupsDark = Color(0xFF17181B)
 internal val switchTrackDark = Color(0xFF1F2025)
 internal val switchThumbDark = Color(0xFF48494E)
 
+// AMOLED theme colors
+internal val backgroundAmoled = Color(0xFF000000)
+internal val surfaceAmoled = Color(0xFF000000)
+internal val surfaceVariantAmoled = Color(0xFF0A0A0A)
+
 // Light Color Scheme
 internal val OverriddenLightColors = lightColorScheme(
     primary = primaryLight,

--- a/core/locale/src/main/res/values/strings.xml
+++ b/core/locale/src/main/res/values/strings.xml
@@ -547,6 +547,7 @@
     <string name="settings__theme_option_auto_system">Auto - System Settings</string>
     <string name="settings__theme_option_dark">Dark</string>
     <string name="settings__theme_option_light">Light</string>
+    <string name="settings__theme_option_amoled_dark">AMOLED Dark</string>
     <string name="tokens__copied_clipboard">Token copied to clipboard!</string>
     <string name="tokens__next_copied_clipboard">Next Token copied to clipboard!</string>
     <string name="tokens__do_you_really_want_to_remove_all_devices">Do you want to permanently delete this 2FA service?</string>

--- a/feature/appsettings/src/main/java/com/twofasapp/feature/appsettings/ui/AppSettingsScreen.kt
+++ b/feature/appsettings/src/main/java/com/twofasapp/feature/appsettings/ui/AppSettingsScreen.kt
@@ -186,6 +186,7 @@ private fun SelectedTheme.toStringResource(): String {
         SelectedTheme.Auto -> stringResource(id = R.string.settings__theme_option_auto)
         SelectedTheme.Light -> stringResource(id = R.string.settings__theme_option_light)
         SelectedTheme.Dark -> stringResource(id = R.string.settings__theme_option_dark)
+        SelectedTheme.AmoledDark -> stringResource(id = R.string.settings__theme_option_amoled_dark)
     }
 }
 

--- a/feature/browserext/src/main/java/com/twofasapp/feature/browserext/ui/request/BrowserExtRequestActivity.kt
+++ b/feature/browserext/src/main/java/com/twofasapp/feature/browserext/ui/request/BrowserExtRequestActivity.kt
@@ -50,6 +50,7 @@ class BrowserExtRequestActivity : ComponentActivity(), AuthAware {
                     SelectedTheme.Auto -> AppTheme.Auto
                     SelectedTheme.Light -> AppTheme.Light
                     SelectedTheme.Dark -> AppTheme.Dark
+                    SelectedTheme.AmoledDark -> AppTheme.AmoledDark
                 },
                 LocalDynamicColors provides settingsRepository.getAppSettings().dynamicColors,
             ) {

--- a/feature/widget/src/main/java/com/twofasapp/feature/widget/ui/settings/WidgetSettingsActivity.kt
+++ b/feature/widget/src/main/java/com/twofasapp/feature/widget/ui/settings/WidgetSettingsActivity.kt
@@ -54,6 +54,7 @@ class WidgetSettingsActivity : ComponentActivity(), AuthAware {
                     SelectedTheme.Auto -> AppTheme.Auto
                     SelectedTheme.Light -> AppTheme.Light
                     SelectedTheme.Dark -> AppTheme.Dark
+                    SelectedTheme.AmoledDark -> AppTheme.AmoledDark
                 },
                 LocalDynamicColors provides settingsRepository.getAppSettings().dynamicColors,
             ) {


### PR DESCRIPTION
Adds pure black theme with #000000 as background.  
When dynamic colors option is enabled, the foreground dynamic color is preserved.

I've seen this feature requested multiple times on the discord server.
The app is great, this is the only thing this app is missing for me to start using it.