### PR TITLE
Fix: Issue #219 Display long Secrets left-aligned when initially loading

### DIFF
--- a/core/designsystem/src/main/java/com/twofasapp/core/design/foundation/textfield/OutlinedTextField.kt
+++ b/core/designsystem/src/main/java/com/twofasapp/core/design/foundation/textfield/OutlinedTextField.kt
@@ -68,7 +68,7 @@ fun OutlinedTextField(
     shape: Shape = TextFieldDefaults.outlinedShape,
     colors: TextFieldColors = textFieldsColors(),
 ) {
-    var textValue by remember { mutableStateOf(TextFieldValue(value, selection = TextRange(value.length))) }
+    var textValue by remember { mutableStateOf(TextFieldValue(value, selection = TextRange(index=0))) }
 
     OutlinedTextField(
         value = textValue.copy(text = value),


### PR DESCRIPTION
When displaying a secret key the cursor position was set to the last available position.
This causes the Textfield to scroll to the right so it can fit the cursor position on screen.

This position is now initialized to 0.
With this change it is easier to copy the codes to other devices when typing them manually. 